### PR TITLE
feat: deduplication by objective value

### DIFF
--- a/configs/config_template.yaml
+++ b/configs/config_template.yaml
@@ -174,6 +174,16 @@ output:
   best_run: false      # Whether to export only the best run's solutions (true) or all runs (false)
   save_config: true   # Save the config in the output directory
 
+  # Deduplication settings: Deduplication happens by (a) solution structure and by objective
+  # function value. These setting are for the latter. Whether to round values before deduplicating
+  # Motivation: If you want to avoid solutions with almost identical objectives
+  deduplicate_solutions: true # Remove solutions that are identical or have identical objectives
+  rounding_decimals: 0        # Precision for objective deduplication:
+                              #  0  = Round to nearest integer (e.g. 884781.3 -> 884781)
+                              #  2  = Round to 2 decimals (e.g. 0.456 -> 0.46)
+                              # -2  = Round to nearest 100 (e.g. 884781 -> 884800)
+                              # null = Do not deduplicate by objective (only by solution structure)
+
   ### Solution sampling strategy
     # Controls which solutions from the optimization run get exported for analysis.
     # During optimization, the best N solutions are tracked (see optimization.run.track_best_n).


### PR DESCRIPTION
Configurable deduplication of solutions in the export pipeline, allowing users to control how solutions with similar or identical objective values are filtered (NOTE: deduplication is optional, as different network structures may have the same objective value and so it may be worth keeping all of them depending on research focus)


The deduplication logic now supports rounding objective values to a configurable precision before removing duplicates, which helps avoid exporting solutions that have effectively the same objective value. Additionally, related configuration options have been added to the template YAML file.

**Deduplication feature enhancements:**

* Added `deduplicate_solutions` and `rounding_decimals` options to `configs/config_template.yaml` to control whether and how solutions are deduplicated based on objective values.
* Updated the solution export logic in `solution_manager.py` to use the new deduplication settings from the config, allowing users to specify the precision for objective value rounding when deduplicating solutions.

**Deduplication implementation improvements:**

* Enhanced the `_remove_duplicate_solutions` method to support objective value rounding and improved fingerprinting for solution structure, ensuring both types of duplicates are efficiently removed. The method now sorts solutions by objective to keep the best version of duplicates and logs the deduplication process with the rounding precision used.